### PR TITLE
qemu 1.4: fix readonly disks

### DIFF
--- a/recipes-openxt/dm-agent/dm-agent-stubdom_git.bbappend
+++ b/recipes-openxt/dm-agent/dm-agent-stubdom_git.bbappend
@@ -10,7 +10,8 @@ SRC_URI += " \
   file://0007-qemu-1.4-Add-graphic-options.patch \
   file://0008-Honor-the-configured-boot-order.patch \
   file://0010-qemu-device-use-net-tap-instead-of-net-bridge.patch \
+  file://0011-qemu-add-disk-readonly-flag.patch \
 "
 
 INC_PR = "r500"
-PR = "${INC_PR}.2"
+PR = "${INC_PR}.5"

--- a/recipes-openxt/dm-agent/dm-agent_git.bbappend
+++ b/recipes-openxt/dm-agent/dm-agent_git.bbappend
@@ -11,7 +11,8 @@ SRC_URI += " \
   file://0008-Honor-the-configured-boot-order.patch \
   file://0009-Pass-the-correct-format-for-cdrom-atapi-passthrough.patch \
   file://0010-qemu-device-use-net-tap-instead-of-net-bridge.patch \
+  file://0011-qemu-add-disk-readonly-flag.patch \
 "
 
 INC_PR="r500"
-PR = "${INC_PR}.2"
+PR = "${INC_PR}.4"

--- a/recipes-openxt/dm-agent/files/0011-qemu-add-disk-readonly-flag.patch
+++ b/recipes-openxt/dm-agent/files/0011-qemu-add-disk-readonly-flag.patch
@@ -1,0 +1,40 @@
+commit adb013e2cb9e79e3f7be0bc7d013d1eb4510a5e5
+Author: Chris Patterson <pattersonc@ainfosec.com>
+Date:   Mon Feb 9 16:13:05 2015 -0500
+
+    qemu-device: add disk readonly option and switch to scsi
+    
+    Signed-off-by: Chris Patterson <pattersonc@ainfosec.com>
+
+diff --git a/src/qemu-device.c b/src/qemu-device.c
+index 68f1437..da3c83b 100644
+--- a/src/qemu-device.c
++++ b/src/qemu-device.c
+@@ -224,21 +224,25 @@ static bool drive_device_parse_options (struct device_model *devmodel,
+     char *media;
+     char *format;
+     char *index;
++    char *readonly;
+     bool res = false;
+ 
+     file = retrieve_option (devmodel, device, "file", drivefile);
+     media = retrieve_option (devmodel, device, "media", drivemedia);
+     format = retrieve_option (devmodel, device, "format", driveformat);
+     index = retrieve_option (devmodel, device, "index", driveindex);
++    readonly = retrieve_option (devmodel, device, "readonly", drivereadonly);
+ 
+     SPAWN_ADD_ARGL (devmodel, end_drive, "-drive");
+     SPAWN_ADD_ARGL (devmodel, end_drive,
+-                    "file=%s,if=ide,index=%s,media=%s,format=%s",
+-                    file, index, media, format);
++                    "file=%s,if=scsi,index=%s,media=%s,format=%s,readonly=%s",
++                    file, index, media, format, readonly);
+ 
+     res = true;
+ 
+ end_drive:
++    free (readonly);
++drivereadonly:
+     free (index);
+ driveindex:
+     free (format);

--- a/recipes-openxt/xenclient-toolstack/xenclient-toolstack/0012-qemu-device-pass-disk-readonly-flag.patch
+++ b/recipes-openxt/xenclient-toolstack/xenclient-toolstack/0012-qemu-device-pass-disk-readonly-flag.patch
@@ -1,0 +1,30 @@
+commit eff0266885e359ca893882af711d998199800e7e
+Author: Chris Patterson <pattersonc@ainfosec.com>
+Date:   Mon Feb 9 16:09:53 2015 -0500
+
+    dmagent: pass readonly flag
+    
+    Signed-off-by: Chris Patterson <pattersonc@ainfosec.com>
+
+diff --git a/xenops/dmagent.ml b/xenops/dmagent.ml
+index 3ec645c..dbf7f5f 100644
+--- a/xenops/dmagent.ml
++++ b/xenops/dmagent.ml
+@@ -168,11 +168,17 @@ let create_device_drive ~trans info domid dmaid dmid id disk =
+ 		if in_stubdom info then sprintf "/dev/xvd%c" character else
+ 			disk.Device.Vbd.physpath
+ 	in
++        let readonlystr =
++                match disk.Device.Vbd.mode with
++                | Device.Vbd.ReadOnly -> "on"
++                | Device.Vbd.ReadWrite -> "off"
++        in
+ 	create_device ~trans domid dmaid dmid "drive" ~devname;
+ 	trans.Xst.write (devpath ^ "/file") file;
+ 	trans.Xst.write (devpath ^ "/media") media;
+ 	trans.Xst.write (devpath ^ "/format") format;
+ 	trans.Xst.write (devpath ^ "/index") (string_of_int index);
++        trans.Xst.write (devpath ^ "/readonly") readonlystr;
+ 	id + 1		
+ 
+ let create_device_cdrom ~trans domid dmaid dmid id disk =

--- a/recipes-openxt/xenclient-toolstack/xenclient-toolstack_git.bbappend
+++ b/recipes-openxt/xenclient-toolstack/xenclient-toolstack_git.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS := "${THISDIR}/${PN}:"
 
-PRINC := "${@int(PRINC) + 500}"
+PRINC := "${@int(PRINC) + 501}"
 
 SRC_URI += " \
   file://0001-xenops-dm-agent-add-drive-device.patch \
@@ -14,5 +14,6 @@ SRC_URI += " \
   file://0009-qemu-1.4-allow-e1000-net-device-for-qemu-by-using-a-.patch \
   file://0010-dmagent-Use-ISO-images-from-dom0.patch \
   file://0011-stubdom-Give-64M-memory.patch \
+  file://0012-qemu-device-pass-disk-readonly-flag.patch \
 "
 


### PR DESCRIPTION
toolstack: pass along new readonly=[on|off] flag to be consumed by dm-agent

dm-agent: switch if=ide to if=scsi to support readonly flag, and pass along.

Signed-off-by: Chris Patterson pattersonc@ainfosec.com
