### PR TITLE
qemu 1.4: fix readonly disks and switch readonly disks to scsi.

### DIFF
--- a/recipes-openxt/dm-agent/dm-agent-stubdom_git.bbappend
+++ b/recipes-openxt/dm-agent/dm-agent-stubdom_git.bbappend
@@ -10,7 +10,8 @@ SRC_URI += " \
   file://0007-qemu-1.4-Add-graphic-options.patch \
   file://0008-Honor-the-configured-boot-order.patch \
   file://0010-qemu-device-use-net-tap-instead-of-net-bridge.patch \
+  file://0011-qemu-add-disk-readonly-flag.patch \
 "
 
 INC_PR = "r500"
-PR = "${INC_PR}.6"
+PR = "${INC_PR}.9"

--- a/recipes-openxt/dm-agent/dm-agent_git.bbappend
+++ b/recipes-openxt/dm-agent/dm-agent_git.bbappend
@@ -11,8 +11,9 @@ SRC_URI += " \
   file://0008-Honor-the-configured-boot-order.patch \
   file://0010-qemu-device-use-net-tap-instead-of-net-bridge.patch \
   file://0011-qemu1.4_dm-agent_use_svirt-interpose.patch;patch=1 \
+  file://0011-qemu-add-disk-readonly-flag.patch \
 "
 
 INC_PR="r500"
-PR = "${INC_PR}.9"
+PR = "${INC_PR}.10"
 

--- a/recipes-openxt/dm-agent/files/0011-qemu-add-disk-readonly-flag.patch
+++ b/recipes-openxt/dm-agent/files/0011-qemu-add-disk-readonly-flag.patch
@@ -1,0 +1,50 @@
+commit 607d201e22c5f227f4eb26131760d3613e87edf0
+Author: Chris Patterson <pattersonc@ainfosec.com>
+Date:   Mon Feb 9 16:13:05 2015 -0500
+
+    qemu-device: add disk readonly option and set readonly disks to scsi
+    
+    qemu's ide does not support readonly=on flag, so set readonly disks
+    to scsi.
+    
+    Signed-off-by: Chris Patterson <pattersonc@ainfosec.com>
+
+diff --git a/src/qemu-device.c b/src/qemu-device.c
+index 68f1437..356672f 100644
+--- a/src/qemu-device.c
++++ b/src/qemu-device.c
+@@ -224,21 +224,32 @@ static bool drive_device_parse_options (struct device_model *devmodel,
+     char *media;
+     char *format;
+     char *index;
++    char *readonly;
+     bool res = false;
+ 
+     file = retrieve_option (devmodel, device, "file", drivefile);
+     media = retrieve_option (devmodel, device, "media", drivemedia);
+     format = retrieve_option (devmodel, device, "format", driveformat);
+     index = retrieve_option (devmodel, device, "index", driveindex);
++    readonly = retrieve_option (devmodel, device, "readonly", drivereadonly);
+ 
+     SPAWN_ADD_ARGL (devmodel, end_drive, "-drive");
+-    SPAWN_ADD_ARGL (devmodel, end_drive,
++
++    // readonly hard disks are scsi, cdrom and writeable disks are ide
++    if ((strcmp(readonly, "off") == 0) || (strcmp(media, "cdrom") == 0)) {
++        SPAWN_ADD_ARGL (devmodel, end_drive,
+                     "file=%s,if=ide,index=%s,media=%s,format=%s",
+                     file, index, media, format);
+-
++    } else {
++        SPAWN_ADD_ARGL (devmodel, end_drive,
++                    "file=%s,if=scsi,index=%s,media=%s,format=%s,readonly=on",
++                    file, index, media, format);
++    }
+     res = true;
+ 
+ end_drive:
++    free (readonly);
++drivereadonly:
+     free (index);
+ driveindex:
+     free (format);

--- a/recipes-openxt/xenclient-toolstack/xenclient-toolstack/0012-qemu-device-pass-disk-readonly-flag.patch
+++ b/recipes-openxt/xenclient-toolstack/xenclient-toolstack/0012-qemu-device-pass-disk-readonly-flag.patch
@@ -1,0 +1,30 @@
+commit eff0266885e359ca893882af711d998199800e7e
+Author: Chris Patterson <pattersonc@ainfosec.com>
+Date:   Mon Feb 9 16:09:53 2015 -0500
+
+    dmagent: pass readonly flag
+    
+    Signed-off-by: Chris Patterson <pattersonc@ainfosec.com>
+
+diff --git a/xenops/dmagent.ml b/xenops/dmagent.ml
+index 3ec645c..dbf7f5f 100644
+--- a/xenops/dmagent.ml
++++ b/xenops/dmagent.ml
+@@ -168,11 +168,17 @@ let create_device_drive ~trans info domid dmaid dmid id disk =
+ 		if in_stubdom info then sprintf "/dev/xvd%c" character else
+ 			disk.Device.Vbd.physpath
+ 	in
++	let readonlystr =
++		match disk.Device.Vbd.mode with
++		| Device.Vbd.ReadOnly -> "on"
++		| Device.Vbd.ReadWrite -> "off"
++	in
+ 	create_device ~trans domid dmaid dmid "drive" ~devname;
+ 	trans.Xst.write (devpath ^ "/file") file;
+ 	trans.Xst.write (devpath ^ "/media") media;
+ 	trans.Xst.write (devpath ^ "/format") format;
+ 	trans.Xst.write (devpath ^ "/index") (string_of_int index);
++	trans.Xst.write (devpath ^ "/readonly") readonlystr;
+ 	id + 1		
+ 
+ let create_device_cdrom ~trans domid dmaid dmid id disk =

--- a/recipes-openxt/xenclient-toolstack/xenclient-toolstack_git.bbappend
+++ b/recipes-openxt/xenclient-toolstack/xenclient-toolstack_git.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS := "${THISDIR}/${PN}:"
 
-PRINC := "${@int(PRINC) + 502}"
+PRINC := "${@int(PRINC) + 503}"
 
 SRC_URI += " \
   file://0001-xenops-dm-agent-add-drive-device.patch \
@@ -14,5 +14,6 @@ SRC_URI += " \
   file://0009-qemu-1.4-allow-e1000-net-device-for-qemu-by-using-a-.patch \
   file://0010-dmagent-Use-ISO-images-from-dom0.patch \
   file://0011-stubdom-Give-64M-memory.patch \
+  file://0012-qemu-device-pass-disk-readonly-flag.patch \
 "
 


### PR DESCRIPTION
toolstack: pass along new readonly=[on|off] flag to be consumed by dm-agent

dm-agent: switch if=ide to if=scsi if readonly==on on and media!=cdrom.

Signed-off-by: Chris Patterson pattersonc@ainfosec.com
