### PR TITLE
qemu 1.4: assign the Xen PCI subsystem to the VGA card

### DIFF
--- a/recipes-openxt/qemu-dm/qemu-dm-1.4.0/vbe-xt-extensions.patch
+++ b/recipes-openxt/qemu-dm/qemu-dm-1.4.0/vbe-xt-extensions.patch
@@ -199,3 +199,14 @@
      uint32_t vbe_start_addr;
      uint32_t vbe_line_offset;
      uint32_t vbe_bank_mask;
+--- a/hw/vga-pci.c
++++ b/hw/vga-pci.c
+@@ -196,6 +196,8 @@ static void vga_class_init(ObjectClass *
+     k->vendor_id = PCI_VENDOR_ID_QEMU;
+     k->device_id = PCI_DEVICE_ID_QEMU_VGA;
+     k->class_id = PCI_CLASS_DISPLAY_VGA;
++    k->subsystem_vendor_id = PCI_VENDOR_ID_XEN;
++    k->subsystem_id = 0x0001;
+     dc->vmsd = &vmstate_vga_pci;
+     dc->props = vga_pci_properties;
+ }


### PR DESCRIPTION
OXT-137

Singed-off-by: Jed Lejosne jed.openxt@gmail.com
