### PR TITLE
[OXT-131] MSI in HVM guests with stub-domain.

### DIFF
--- a/recipes-core/images/xenclient-dom0-image.bbappend
+++ b/recipes-core/images/xenclient-dom0-image.bbappend
@@ -1,4 +1,4 @@
-PRINC := "${@int(PRINC) + 500}"
+PRINC := "${@int(PRINC) + 501}"
 
 IMAGE_INSTALL += " qemu-dm "
 

--- a/recipes-extended/xen/files/stubdomain-msi-irq-access.patch
+++ b/recipes-extended/xen/files/stubdomain-msi-irq-access.patch
@@ -1,0 +1,56 @@
+--- a/xen/arch/x86/physdev.c
++++ b/xen/arch/x86/physdev.c
+@@ -141,8 +144,18 @@ int physdev_map_pirq(domid_t domid, int
+ 
+     case MAP_PIRQ_TYPE_MSI:
+         irq = *index;
+-        if ( irq == -1 )
++        if ( irq == -1 ) {
+             irq = create_irq(NUMA_NO_NODE);
++            /* Allow stubdomain to deal with this IRQ. */
++            if ( d == current->domain->target )
++            {
++                ret = irq_permit_access(current->domain, irq);
++                if ( ret )
++                    printk(XENLOG_G_ERR "Could not grant stubdom%u access to IRQ%d (error %d)\n",
++                           current->domain->domain_id, irq, ret);
++
++            }
++        }
+ 
+         if ( irq < nr_irqs_gsi || irq >= nr_irqs )
+         {
+@@ -211,7 +229,13 @@ int physdev_map_pirq(domid_t domid, int
+     spin_unlock(&d->event_lock);
+     spin_unlock(&pcidevs_lock);
+     if ( (ret != 0) && (type == MAP_PIRQ_TYPE_MSI) && (*index == -1) )
++    {
++        if ( (d == current->domain->target) &&
++             irq_deny_access(current->domain, irq) )
++            printk(XENLOG_G_ERR "dom%d: could not revoke access to IRQ%d.\n",
++                   d->domain_id, irq );
+         destroy_irq(irq);
++    }
+  free_domain:
+     rcu_unlock_domain(d);
+     return ret;
+@@ -242,6 +266,18 @@ int physdev_unmap_pirq(domid_t domid, in
+ 
+     spin_lock(&pcidevs_lock);
+     spin_lock(&d->event_lock);
++    /* Remove stubdomain's permission on IRQ. */
++    if (d == current->domain->target)
++    {
++        int irq;
++
++        irq = domain_pirq_to_irq(d, pirq);
++        if ( irq <= 0 )
++            printk(XENLOG_G_ERR "dom%d invalid pirq:%d!\n", d->domain_id, pirq);
++        else if ( irq_deny_access(current->domain, irq) )
++            printk(XENLOG_G_ERR "Could not revoke stubdom%u access to IRQ%d.\n",
++                        current->domain->domain_id, irq);
++    }
+     ret = unmap_domain_pirq(d, pirq);
+     spin_unlock(&d->event_lock);
+     spin_unlock(&pcidevs_lock);
+

--- a/recipes-extended/xen/xen.bbappend
+++ b/recipes-extended/xen/xen.bbappend
@@ -3,3 +3,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI +=  " \
              file://stubdomain-msi-irq-access.patch;patch=1 \
              "
+
+PRINC := "${@int(PRINC) + 500}"

--- a/recipes-extended/xen/xen.bbappend
+++ b/recipes-extended/xen/xen.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI +=  " \
+             file://stubdomain-msi-irq-access.patch;patch=1 \
+             "

--- a/recipes-kernel/linux/linux-xenclient-dom0-3.11/pciback-restrictive-attr.patch
+++ b/recipes-kernel/linux/linux-xenclient-dom0-3.11/pciback-restrictive-attr.patch
@@ -1,0 +1,98 @@
+--- a/drivers/xen/xen-pciback/pci_stub.c
++++ b/drivers/xen/xen-pciback/pci_stub.c
+@@ -1296,15 +1296,14 @@ out:
+ static DRIVER_ATTR(quirks, S_IRUSR | S_IWUSR, pcistub_quirk_show,
+ 		   pcistub_quirk_add);
+ 
+-static ssize_t permissive_add(struct device_driver *drv, const char *buf,
+-			      size_t count)
++static int set_confspace_policy(const char *dev_str, bool permissive)
+ {
+ 	int domain, bus, slot, func;
+ 	int err;
+ 	struct pcistub_device *psdev;
+ 	struct xen_pcibk_dev_data *dev_data;
+ 
+-	err = str_to_slot(buf, &domain, &bus, &slot, &func);
++	err = str_to_slot(dev_str, &domain, &bus, &slot, &func);
+ 	if (err)
+ 		goto out;
+ 
+@@ -1320,22 +1319,33 @@ static ssize_t permissive_add(struct dev
+ 		err = -ENXIO;
+ 		goto release;
+ 	}
+-	if (!dev_data->permissive) {
+-		dev_data->permissive = 1;
++
++	if (!dev_data->permissive && permissive) {
+ 		/* Let user know that what they're doing could be unsafe */
+ 		dev_warn(&psdev->dev->dev, "enabling permissive mode "
+ 			 "configuration space accesses!\n");
+ 		dev_warn(&psdev->dev->dev,
+ 			 "permissive mode is potentially unsafe!\n");
+ 	}
++	dev_data->permissive = permissive;
+ release:
+ 	pcistub_device_put(psdev);
+ out:
+-	if (!err)
+-		err = count;
+ 	return err;
+ }
+ 
++static ssize_t permissive_add(struct device_driver *drv, const char *buf,
++			      size_t count)
++{
++	int err;
++
++	err = set_confspace_policy(buf, true);
++	if (err) {
++		return err;
++	}
++	return count;
++}
++
+ static ssize_t permissive_show(struct device_driver *drv, char *buf)
+ {
+ 	struct pcistub_device *psdev;
+@@ -1361,6 +1371,20 @@ static ssize_t permissive_show(struct de
+ static DRIVER_ATTR(permissive, S_IRUSR | S_IWUSR, permissive_show,
+ 		   permissive_add);
+ 
++static ssize_t restrictive_add(struct device_driver *drv, const char *buf,
++			       size_t count)
++{
++	int err;
++
++	err = set_confspace_policy(buf, false);
++	if (err) {
++		return err;
++	}
++	return count;
++}
++static DRIVER_ATTR(restrictive, S_IWUSR, NULL, restrictive_add);
++
++
+ static void pcistub_exit(void)
+ {
+ 	driver_remove_file(&xen_pcibk_pci_driver.driver, &driver_attr_new_slot);
+@@ -1369,6 +1393,8 @@ static void pcistub_exit(void)
+ 	driver_remove_file(&xen_pcibk_pci_driver.driver, &driver_attr_slots);
+ 	driver_remove_file(&xen_pcibk_pci_driver.driver, &driver_attr_quirks);
+ 	driver_remove_file(&xen_pcibk_pci_driver.driver,
++			   &driver_attr_restrictive);
++	driver_remove_file(&xen_pcibk_pci_driver.driver,
+ 			   &driver_attr_permissive);
+ 	driver_remove_file(&xen_pcibk_pci_driver.driver,
+ 			   &driver_attr_irq_handlers);
+@@ -1460,6 +1486,9 @@ static int __init pcistub_init(void)
+ 	if (!err)
+ 		err = driver_create_file(&xen_pcibk_pci_driver.driver,
+ 					 &driver_attr_permissive);
++	if (!err)
++		err = driver_create_file(&xen_pcibk_pci_driver.driver,
++					 &driver_attr_restrictive);
+ 
+ 	if (!err)
+ 		err = driver_create_file(&xen_pcibk_pci_driver.driver,

--- a/recipes-kernel/linux/linux-xenclient-dom0_3.11.bbappend
+++ b/recipes-kernel/linux/linux-xenclient-dom0_3.11.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAMETA := "${THISDIR}/${PN}-3.11:"
+FILESEXTRAPATHS_prepend := "${FILESEXTRAMETA}:"
+
+SRC_URI += " \
+            file://pciback-restrictive-attr.patch;patch=1 \
+            "

--- a/recipes-kernel/linux/linux-xenclient-dom0_3.11.bbappend
+++ b/recipes-kernel/linux/linux-xenclient-dom0_3.11.bbappend
@@ -4,3 +4,5 @@ FILESEXTRAPATHS_prepend := "${FILESEXTRAMETA}:"
 SRC_URI += " \
             file://pciback-restrictive-attr.patch;patch=1 \
             "
+
+PRINC := "${@int(PRINC) + 500}"

--- a/recipes-openxt/xenclient-toolstack/xenclient-toolstack/0013-stubdom-pciback-permissive.patch
+++ b/recipes-openxt/xenclient-toolstack/xenclient-toolstack/0013-stubdom-pciback-permissive.patch
@@ -1,0 +1,83 @@
+commit 7e5b4035a1931f0b9333ecd28ca74828638f0bcf
+Author: Eric Chanudet <eric.chanudet@gmail.com>
+Date:   Thu Mar 12 15:02:43 2015 +0100
+
+    [pci-pt] pciback use permissive for stubdoms
+    
+    Stub-domains are given write permission on the config-space of PCI devices passed-through to
+    their domain, so Qemu can issue writes directly.
+    
+    OXT-131.
+
+diff --git a/xenops/device.ml b/xenops/device.ml
+index 126dd38..d3721a4 100644
+--- a/xenops/device.ml
++++ b/xenops/device.ml
+@@ -1154,8 +1154,16 @@ let do_flr dev =
+   debug "Device.Pci.do_flr %s" devstr;
+   (try write_string_to_file p "1" with _ -> debug "Device.Pci.do_flr %s FAILED" devstr);
+   debug "Device.Pci.do_flr %s done" devstr
+-   
+-let add_noexn ~xc ~xs ~hvm ?(assign=true) ?(pvpci=true) ?(flr=false) pcidevs_list domid devid =
++
++(* set pciback configuration space policy for this device to permissive *)
++let set_permissive dev =
++  let devstr = string_of_desc dev.desc in
++  let p = "/sys/bus/pci/drivers/pciback/permissive" in
++  debug "Device.Pci.switch_permissive %s" devstr;
++  (try write_string_to_file p devstr with _ -> debug "Device.Pci.switch_permissive %s FAILED" devstr);
++  debug "Device.Pci.switch_permissive %s done" devstr
++
++let add_noexn ~xc ~xs ~hvm ?(assign=true) ?(pvpci=true) ?(flr=false) ?(permissive=false) pcidevs_list domid devid =
+ 	let msitranslate = (List.hd pcidevs_list).msitranslate in
+ 	let power_mgmt   = (List.hd pcidevs_list).power_mgmt in
+ 	let pcidevs = List.map (fun info ->
+@@ -1180,6 +1188,9 @@ let add_noexn ~xc ~xs ~hvm ?(assign=true) ?(pvpci=true) ?(flr=false) pcidevs_lis
+ 	) pcidevs_list in
+ 
+ 	List.iter (fun (dev, resources) ->
++		if (permissive) then (
++			set_permissive dev
++		);
+ 		debug "Device.Pci.add domid=%d %d %d %d %d assign=%s pvpci=%s" domid dev.desc.domain dev.desc.bus dev.desc.slot dev.desc.func (string_of_bool assign) (string_of_bool pvpci);
+ 		if (hvm || pvpci) && assign then (
+ 			Xc.domain_assign_device xc domid (dev.desc.domain, dev.desc.bus, dev.desc.slot, dev.desc.func);
+@@ -1219,8 +1230,8 @@ let add_noexn ~xc ~xs ~hvm ?(assign=true) ?(pvpci=true) ?(flr=false) pcidevs_lis
+ 	] in
+ 	Generic.add_device ~xs device (others @ List.concat xsdevs @ backendlist) frontendlist
+ 
+-let add ~xc ~xs ~hvm ?assign ?pvpci ?flr pcidevs domid devid =
+-	try add_noexn ~xc ~xs ~hvm ?assign ?pvpci ?flr pcidevs domid devid
++let add ~xc ~xs ~hvm ?assign ?pvpci ?flr ?permissive pcidevs domid devid =
++	try add_noexn ~xc ~xs ~hvm ?assign ?pvpci ?flr ?permissive pcidevs domid devid
+ 	with exn ->
+ 		raise (Cannot_add (pcidevs, exn))
+ 
+diff --git a/xenops/device.mli b/xenops/device.mli
+index b8cf5d6..065242a 100644
+--- a/xenops/device.mli
++++ b/xenops/device.mli
+@@ -195,6 +195,7 @@ sig
+ 		-> ?assign:bool
+ 		-> ?pvpci:bool
+ 		-> ?flr:bool
++		-> ?permissive:bool
+ 		-> dev list -> Xc.domid -> int -> unit
+ 	val release : xc:Xc.handle -> xs:Xs.xsh -> hvm:bool
+ 	       -> dev list -> Xc.domid -> int -> unit
+diff --git a/xenops/dm.ml b/xenops/dm.ml
+index 14042b5..e1ac62c 100644
+--- a/xenops/dm.ml
++++ b/xenops/dm.ml
+@@ -284,8 +284,9 @@ let create_dm_stubdom ~xc ~xs dmargs info target_domid uuid =
+ 	) info.vifs;
+ 	(* adding pcis *)
+ 	List.iter (fun (devid, devs) ->
+-		(* stubdom PCIs are not actually assigned *)
+-		Device.PCI.add ~xc ~xs ~hvm:false ~assign:false ~pvpci:true devs stubdom_domid devid
++		(* stubdom PCIs are not actually assigned.
++		 * Grant PCI devices config-space write-access to the stub-domain *)
++		Device.PCI.add ~xc ~xs ~hvm:false ~assign:false ~pvpci:true ~permissive:true devs stubdom_domid devid
+ 	) info.pcis;
+ 
+ 	Device.Vfb.add ~xc ~xs ~hvm:false stubdom_domid;

--- a/recipes-openxt/xenclient-toolstack/xenclient-toolstack/0014-stubdom-pciback-reset-perm.patch
+++ b/recipes-openxt/xenclient-toolstack/xenclient-toolstack/0014-stubdom-pciback-reset-perm.patch
@@ -1,0 +1,39 @@
+commit c476fac7a31d2c380e3de9b9e0253f27122e58f9
+Author: Eric Chanudet <eric.chanudet@gmail.com>
+Date:   Thu Mar 12 15:10:18 2015 +0100
+
+    [pci-pt] Set pciback restrictive swhen stubdom halts
+    
+    Use added restrictive sysfs node to reset pciback permissions on passed
+    through devices when the stub domain is halted.
+
+diff --git a/xenops/device.ml b/xenops/device.ml
+index d3721a4..d8721d1 100644
+--- a/xenops/device.ml
++++ b/xenops/device.ml
+@@ -1163,6 +1163,14 @@ let set_permissive dev =
+   (try write_string_to_file p devstr with _ -> debug "Device.Pci.switch_permissive %s FAILED" devstr);
+   debug "Device.Pci.switch_permissive %s done" devstr
+ 
++(* set pciback configuration space policy for this device to restrictive *)
++let set_restrictive dev =
++  let devstr = string_of_desc dev.desc in
++  let p = "/sys/bus/pci/drivers/pciback/restrictive" in
++  debug "Device.Pci.switch_restrictive %s" devstr;
++  (try write_string_to_file p devstr with _ -> debug "Device.Pci.switch_restrictive %s FAILED" devstr);
++  debug "Device.Pci.switch_restrictive %s done" devstr
++
+ let add_noexn ~xc ~xs ~hvm ?(assign=true) ?(pvpci=true) ?(flr=false) ?(permissive=false) pcidevs_list domid devid =
+ 	let msitranslate = (List.hd pcidevs_list).msitranslate in
+ 	let power_mgmt   = (List.hd pcidevs_list).power_mgmt in
+@@ -1262,7 +1270,9 @@ let release ~xc ~xs ~hvm pcidevs domid devid =
+ 			report_errors (fun _ -> Xc.domain_irq_permission xc domid resources.irq false)
+ 		);
+ 		debug "remove resource access grants";
+-		report_errors (fun _ -> grant_access_resources xc domid resources.memaddr false)
++		report_errors (fun _ -> grant_access_resources xc domid resources.memaddr false);
++		(* Restore restrictive permission by default ... *)
++		if (hvm = false) then set_restrictive dev
+ 	in
+ 
+ 	List.iter (fun (dev, resources) ->

--- a/recipes-openxt/xenclient-toolstack/xenclient-toolstack_git.bbappend
+++ b/recipes-openxt/xenclient-toolstack/xenclient-toolstack_git.bbappend
@@ -16,5 +16,6 @@ SRC_URI += " \
   file://0011-stubdom-Give-64M-memory.patch \
   file://0012-qemu-device-pass-disk-readonly-flag.patch \
   file://0013-stubdom-pciback-permissive.patch \
+  file://0014-stubdom-pciback-reset-perm.patch \
 "
 

--- a/recipes-openxt/xenclient-toolstack/xenclient-toolstack_git.bbappend
+++ b/recipes-openxt/xenclient-toolstack/xenclient-toolstack_git.bbappend
@@ -15,5 +15,6 @@ SRC_URI += " \
   file://0010-dmagent-Use-ISO-images-from-dom0.patch \
   file://0011-stubdom-Give-64M-memory.patch \
   file://0012-qemu-device-pass-disk-readonly-flag.patch \
+  file://0013-stubdom-pciback-permissive.patch \
 "
 


### PR DESCRIPTION
Allow Qemu while running in the stub-domain to set up MSI for the PCI device passed through to its guest.

Give the stub-domain permission to map/unmap the pirq created for the occasion.
Give write access to the configuration space of the PCI device passed-through, using pci-front.
